### PR TITLE
fix: fix `group by` causing duplicate flaky test runs

### DIFF
--- a/lib/devhub/coverbot/test_reports/actions/get_flaky_tests_test.exs
+++ b/lib/devhub/coverbot/test_reports/actions/get_flaky_tests_test.exs
@@ -42,6 +42,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "always_failing",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "Always fails", stacktrace: "always fail trace"},
       inserted_at: ~U[2024-01-01 10:00:00Z]
     )
 
@@ -50,6 +51,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "failed_before_cutoff",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "random message", stacktrace: "random stacktrace"},
       inserted_at: ~U[2024-01-01 10:00:00Z]
     )
 
@@ -59,6 +61,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "flaky",
       class_name: "TestModule2",
       status: :failed,
+      info: %{message: "random message", stacktrace: "random stacktrace"},
       inserted_at: ~U[2024-01-01 10:00:00Z]
     )
 
@@ -75,6 +78,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "flaky",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "Error A", stacktrace: "trace A"},
       inserted_at: ~U[2024-01-02 10:00:00Z]
     )
 
@@ -83,6 +87,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "always_failing",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "random message 2", stacktrace: "random stacktrace 2"},
       inserted_at: ~U[2024-01-02 10:00:00Z]
     )
 
@@ -107,6 +112,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "flaky",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "Error B", stacktrace: "trace B"},
       inserted_at: ~U[2024-01-03 10:00:00Z]
     )
 
@@ -115,6 +121,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "always_failing",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "random message 3", stacktrace: "random stacktrace 3"},
       inserted_at: ~U[2024-01-03 10:00:00Z]
     )
 
@@ -147,6 +154,7 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
       test_name: "always_failing",
       class_name: "TestModule",
       status: :failed,
+      info: %{message: "last always flaky message", stacktrace: "last always flaky stacktrace"},
       inserted_at: ~U[2024-01-04 10:00:00Z]
     )
 
@@ -163,13 +171,16 @@ defmodule Devhub.Coverbot.TestReports.Actions.GetFlakyTestsTest do
                class_name: "TestModule",
                failure_count: 3,
                first_failure_at: always_failing_first_failure_datetime,
-               test_name: "always_failing"
+               test_name: "always_failing",
+               info: %{"message" => "last always flaky message", "stacktrace" => "last always flaky stacktrace"}
              },
              %{
                class_name: "TestModule",
                failure_count: 2,
                first_failure_at: flaky_first_failure_datetime,
-               test_name: "flaky"
+               test_name: "flaky",
+               # returns info for the last run
+               info: %{"message" => "Error B", "stacktrace" => "trace B"}
              }
            ] =
              Coverbot.get_flaky_tests(test_suite.id, 3)

--- a/lib/devhub_web/live/coverbot/test_reports/test_suite.ex
+++ b/lib/devhub_web/live/coverbot/test_reports/test_suite.ex
@@ -143,13 +143,13 @@ defmodule DevhubWeb.Live.Coverbot.TestReports.TestSuite do
                 <div>
                   <span class="font-semibold">Error message</span>:
                   <div class="bg-surface-3 mt-4 overflow-auto rounded p-4 text-sm">
-                    <pre class="font-mono whitespace-pre-wrap">{String.trim(test_run.info.message)}</pre>
+                    <pre class="font-mono whitespace-pre-wrap">{String.trim(test_run.info["message"])}</pre>
                   </div>
                 </div>
                 <div class="pt-4">
                   <span class="font-semibold">Stacktrace</span>:
                   <div class="bg-surface-3 mt-4 overflow-auto rounded p-4 text-sm">
-                    <pre class="font-mono whitespace-pre-wrap">{String.trim(test_run.info.stacktrace)}</pre>
+                    <pre class="font-mono whitespace-pre-wrap">{String.trim(test_run.info["stacktrace"])}</pre>
                   </div>
                 </div>
               </div>

--- a/lib/devhub_web/live/coverbot/test_reports/test_suite_test.exs
+++ b/lib/devhub_web/live/coverbot/test_reports/test_suite_test.exs
@@ -38,8 +38,8 @@ defmodule DevhubWeb.Live.Coverbot.TestReports.TestSuiteTest do
         first_failure_at: ~U[2024-01-01 10:00:00Z],
         commit_sha: "abc123",
         info: %{
-          message: "Test failed randomly",
-          stacktrace: "at TestModule.flaky_test_example(TestModule.java:42)"
+          "message" => "Test failed randomly",
+          "stacktrace" => "at TestModule.flaky_test_example(TestModule.java:42)"
         }
       }
 


### PR DESCRIPTION
We were getting a few duplicate entries, because I included `info` (containing the stacktrace) in the `group_by` (in order to select it). This fixes it.

Reproduction test (failing before fix):
<img width="1323" height="649" alt="Screenshot 2025-08-20 at 20 57 51" src="https://github.com/user-attachments/assets/7d5f26a3-311e-4393-80aa-43f31ba88aa5" />
